### PR TITLE
FEAT: 빙고 플레이 페이지 기능추가

### DIFF
--- a/web/src/components/BingoBoard.js
+++ b/web/src/components/BingoBoard.js
@@ -6,20 +6,27 @@ import BingoCell from './BingoCell';
 const GridRow = styled(Grid)({
   minHeight: '100px',
   borderBottom: '1px solid',
+  borderColor: 'black',
 });
 
 const Wrapper = styled('div')({
   borderTop: '1px solid',
   borderRight: '1px solid',
+  borderColor: 'black',
 });
 
-function BingoBoard({ board, size }) {
+function BingoBoard({ board, size, playable, progress }) {
   const rows = [];
   let cells = [];
   for (const [index, cell] of board.entries()) {
     cells.push(
       <Grid key={index} item xs zeroMinWidth>
-        <BingoCell index={index} cell={cell} />
+        <BingoCell
+          index={index}
+          cell={cell}
+          playable={playable}
+          selected={progress.boardStatus[index]}
+        />
       </Grid>
     );
 

--- a/web/src/components/BingoCell.js
+++ b/web/src/components/BingoCell.js
@@ -1,24 +1,38 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Box, Typography, useMediaQuery } from '@material-ui/core';
+import { styled } from '@material-ui/core/styles';
+import { useBingoDispatch } from '../contexts/BingoContext';
 import { useTheme } from '@material-ui/core/styles';
 
-function BingoCell({ index, cell }) {
+const CellWrapper = styled(Box)({
+  borderLeft: '1px solid black',
+  display: 'flex',
+  textAlign: 'center',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '100%',
+});
+
+function BingoCell({ index, cell, playable, selected }) {
   const theme = useTheme();
   const xs = useMediaQuery(theme.breakpoints.only('xs'));
 
+  const dispatch = useBingoDispatch();
+
+  const onCellClick = useCallback(() => {
+    dispatch({ type: 'UPDATE_BINGO_PROGRESS', index });
+  }, [index, dispatch]);
+
   return (
-    <Box
+    <CellWrapper
       px={1}
-      borderLeft={1}
-      height="100%"
-      display="flex"
-      textAlign="center"
-      justifyContent="center"
-      alignItems="center"
       style={{ wordBreak: xs ? 'normal' : 'keep-all' }}
+      onClick={playable ? onCellClick : null}
+      color={selected ? 'primary.contrastText' : 'black'}
+      bgcolor={selected ? 'primary.main' : 'white'}
     >
       <Typography variant="body2">{cell.title}</Typography>
-    </Box>
+    </CellWrapper>
   );
 }
 

--- a/web/src/contexts/BingoContext.js
+++ b/web/src/contexts/BingoContext.js
@@ -8,6 +8,12 @@ const initialState = {
     data: null,
     error: null,
   },
+  progress: {
+    boardStatus: null,
+    bingoCount: null,
+    bingoLines: null,
+    boardSize: null,
+  },
 };
 
 const loadingState = {
@@ -36,6 +42,20 @@ function bingoReducer(state, action) {
         bingo: loadingState,
       };
     case 'GET_BINGO_SUCCESS':
+      const boardSize = action.data.size;
+      const statusArray = new Array(boardSize * boardSize).fill(false);
+
+      return {
+        ...state,
+        bingo: successState(action.data),
+        progress: {
+          ...state.progress,
+          boardSize,
+          boardStatus: statusArray,
+          bingoCount: 0,
+        },
+      };
+    case 'GET_BINGO_REFRESH_SUCCESS':
       return {
         ...state,
         bingo: successState(action.data),
@@ -45,9 +65,100 @@ function bingoReducer(state, action) {
         ...state,
         bingo: errorState(action.error),
       };
+    case 'UPDATE_BINGO_PROGRESS':
+      const boardStatus = updateBoardStatus(state.progress, action.index);
+      const { totalCount, bingoLines } = updateBingoCount(boardStatus, state.progress.boardSize);
+      return {
+        ...state,
+        progress: {
+          ...state.progress,
+          boardStatus,
+          bingoCount: totalCount,
+          bingoLines,
+        },
+      };
+    case 'SUBMIT_BINGO_RESULT':
+      // TODO(mskwon1): 서버쪽으로 데이터 보내고 결과 받는 부분 구현.
+      console.log('result submitted');
+      return {
+        ...state,
+      };
     default:
       throw new Error(`Unhandled action type: ${action.type}`);
   }
+}
+
+function updateBoardStatus(progress, updateIndex) {
+  const boardStatus = progress.boardStatus.map((value, index) => {
+    if (index === updateIndex) {
+      return !value;
+    }
+    return value;
+  });
+
+  return boardStatus;
+}
+
+function updateBingoCount(boardStatus, boardSize) {
+  const bingoLines = { h: [], v: [], d: [] };
+  let totalCount = 0;
+
+  // 가로줄 검사.
+  for (let i = 0; i < boardStatus.length; i += boardSize) {
+    let rowCount = 0;
+    for (let j = 0; j < boardSize; j++) {
+      if (boardStatus[i + j]) {
+        rowCount++;
+      }
+    }
+    if (rowCount === boardSize) {
+      totalCount++;
+      bingoLines['h'].push(i / boardSize + 1);
+    }
+  }
+
+  // 세로줄 검사.
+  for (let i = 0; i < boardSize; i++) {
+    let colCount = 0;
+    for (let j = 0; j < boardStatus.length; j += boardSize) {
+      if (boardStatus[i + j]) {
+        colCount++;
+      }
+    }
+    if (colCount === boardSize) {
+      totalCount++;
+      bingoLines['v'].push(i + 1);
+    }
+  }
+
+  // 우하향 대각선 검사.
+  let diagDownCount = 0;
+  for (let i = 0; i < boardStatus.length; i += boardSize + 1) {
+    if (boardStatus[i]) {
+      diagDownCount++;
+    }
+  }
+  if (diagDownCount === boardSize) {
+    totalCount++;
+    bingoLines['d'].push(1);
+  }
+
+  let diagUpCount = 0;
+  // 우상향 대각선 검사.
+  for (let i = boardSize - 1; i < boardStatus.length - boardSize + 1; i += boardSize - 1) {
+    if (boardStatus[i]) {
+      diagUpCount++;
+    }
+  }
+  if (diagUpCount === boardSize) {
+    totalCount++;
+    bingoLines['d'].push(2);
+  }
+
+  return {
+    bingoLines,
+    totalCount,
+  };
 }
 
 const BingoStateContext = createContext();
@@ -79,11 +190,31 @@ export function useBingoDispatch() {
   return context;
 }
 
+/**
+ * 빙고 데이터 받아올 때 사용(progress 초기화됨).
+ * @param {Function} dispatch 컨텍스트 디스패쳐
+ * @param {Number} id 받아올 빙고 id
+ */
 export async function getBingo(dispatch, id) {
   dispatch({ type: 'GET_BINGO' });
   try {
     const response = await axios.get(`${serverBaseUrl}/bingos/${id}`);
     dispatch({ type: 'GET_BINGO_SUCCESS', data: response.data });
+  } catch (error) {
+    dispatch({ type: 'GET_BINGO_ERROR', error });
+  }
+}
+
+/**
+ * progress 안건드리고 bingo 데이터 다시 받아올 때 사용하세요.
+ * @param {Function} dispatch 컨텍스트 디스패쳐
+ * @param {Number} id 빙고 id
+ */
+export async function refreshBingo(dispatch, id) {
+  dispatch({ type: 'GET_BINGO' });
+  try {
+    const response = await axios.get(`${serverBaseUrl}/bingos/${id}`);
+    dispatch({ type: 'GET_BINGO_REFRESH_SUCCESS', data: response.data });
   } catch (error) {
     dispatch({ type: 'GET_BINGO_ERROR', error });
   }

--- a/web/src/pages/BingoPlayPage.js
+++ b/web/src/pages/BingoPlayPage.js
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { Button, Container, Typography } from '@material-ui/core';
+import React, { useCallback, useEffect } from 'react';
+import { useParams, useHistory } from 'react-router-dom';
+import { Button, Collapse, Container, Paper, Typography } from '@material-ui/core';
 import DoneIcon from '@material-ui/icons/Done';
 import { styled } from '@material-ui/core/styles';
-import { useBingoState, useBingoDispatch, getBingo } from '../contexts/BingoContext';
+import { useBingoState, useBingoDispatch, getBingo, refreshBingo } from '../contexts/BingoContext';
 import BingoBoard from '../components/BingoBoard';
 
 const MainContainer = styled(Container)({
@@ -18,12 +18,19 @@ const TitleContainer = styled('div')({
   marginBottom: '1rem',
 });
 
+const CountContainer = styled(Paper)({
+  marginTop: '1rem',
+  paddingTop: '0.5rem',
+  paddingBottom: '0.5rem',
+});
+
 const SaveButton = styled(Button)({
   marginTop: '1rem',
 });
 
 function BingoPlayPage() {
   const { id } = useParams();
+  const history = useHistory();
   const state = useBingoState();
   const dispatch = useBingoDispatch();
 
@@ -32,6 +39,14 @@ function BingoPlayPage() {
   }, [dispatch, id]);
 
   const { loading, data, error } = state.bingo;
+  const { progress } = state;
+
+  // 결과보기 버튼 클릭시 호출할 함수.
+  const onSave = useCallback(async () => {
+    dispatch({ type: 'SUBMIT_BINGO_RESULT' });
+    await refreshBingo(dispatch, id);
+    history.push(`/bingo/${id}/result`);
+  }, [dispatch, id, history]);
 
   if (data) {
     // 빙고판 사이즈에 따라서 메인 컨테이너 크기 조정.
@@ -50,15 +65,21 @@ function BingoPlayPage() {
           <Typography variant="h3">{data.title}</Typography>
           <Typography variant="subtitle1">{data.description}</Typography>
         </TitleContainer>
-        <BingoBoard board={data.board} size={data.size} />
+        <BingoBoard board={data.board} size={data.size} playable progress={progress} />
+        <Collapse in={progress.bingoCount > 0}>
+          <CountContainer elevation={3}>
+            <Typography>{progress.bingoCount} 빙고!</Typography>
+          </CountContainer>
+        </Collapse>
         <SaveButton
           variant="contained"
           color="primary"
           size="large"
           startIcon={<DoneIcon />}
           fullWidth
+          onClick={onSave}
         >
-          저장하기
+          결과보기
         </SaveButton>
       </MainContainer>
     );


### PR DESCRIPTION
resolves: #5

### `BingoContext` 내용 추가
플레이 관련 데이터 `progress`에 저장
- `boardStatus` : 각 셀이 선택됐는지 안됐는지 정보 저장한 배열(`boolean`)
- `bingoCount` : 현재 빙고 몇개인지
- `boardSize` : 빙고 보드 가로/세로 사이즈
- `bingoLines` : 현재 빙고 된 라인이 뭐뭐인지(가로 `h`, 세로 `v`, 대각선 `d`로 구성)
![context-bingoLines](https://user-images.githubusercontent.com/39542963/104456087-857a6a80-55eb-11eb-980e-5b5a056c1908.png)
### `BingoBoard`, `BingoCell` 내용 추가
- `playable` props: 보드를 플레이 가능한 상태로 렌더링 하려면 true
- `progress` : 플레이 진행 상태 관련 데이터, 컨텍스트에서 받아와서 쓰면됨
### `BingoPlayPage` 내용 추가
- 현재 빙고 몇개인지 보여주는 칸 추가, `Collapse` 효과 부여
- 저장하기 버튼 -> 결과보기로 텍스트 수정
- 저장하기 버튼 클릭시 빙고 데이터 다시 받아오고 `/bingo/:id/result` 쪽으로 이동
### 실행예시
![1](https://user-images.githubusercontent.com/39542963/104456659-59abb480-55ec-11eb-80eb-fa6686c9c77b.gif)

